### PR TITLE
Fixing small errors in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   workflow_dispatch:
   release:
-    types: [created]
+    types:
+    - created
 
 jobs:
   release:
@@ -29,3 +30,4 @@ jobs:
         with:
           pat: ${{ secrets.VS_PAT }}
           manifestPath: ${{ github.workspace }}\Release\PipelinesTasks\PRMetrics\vss-extension.json
+          vsixPath: ${{ github.workspace }}\Release\PipelinesTasks\PRMetrics\ms-omex.prmetrics-1.0.0.vsix


### PR DESCRIPTION
Fixing a small number of errors within release.yml that were only possible to detect after running the GitHub Action for the first time. In the interim, it is still possible to publish manually.