### PR TITLE
Making PR Metrics public

### DIFF
--- a/PipelinesTasks/PRMetrics/vss-extension.json
+++ b/PipelinesTasks/PRMetrics/vss-extension.json
@@ -5,6 +5,7 @@
   "version": "1.0.0",
   "publisher": "ms-omex",
   "description": "Updates the title, description, and comments of pull requests to provide at-a-glance metrics.",
+  "public": true,
   "tags": [
     "Extension",
     "Marketplace",


### PR DESCRIPTION
Adding the "public" flag to the PR Metrics manifest to make it available through the public Azure DevOps Marketplace.