### PR TITLE
Adding markdown link validation to build

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,14 +19,14 @@ additional questions or comments.
 
 ## Coding Style
 
-There is an [`.editorconfig`](.editorconfig) file in the root of the project
+There is an [`.editorconfig`](../.editorconfig) file in the root of the project
 specifying some simple formatting guidelines. In addition to adhering to those,
 you should follow the pattern of what you see in existing code where possible.
 
 ## Code Overview
 
 The repository is organized into a set of different extensions, as outlined in
-the [README](README.md).
+the [README](../README.md).
 
 ## Updating an Extension
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,11 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_POWERSHELL: false
 
+      - name: Validate Markdown Links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: .github/linters/markdown-link-check.json
+
       - name: Validate .markdownlint.json
         uses: Zingabopp/JsonValidate-Action@v1
         with:
@@ -145,10 +150,10 @@ jobs:
           json-schema: https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json
           use-draft: draft-07
 
-      - name: JSON VALIDATION – Validate task.json – Download tasks.schema.json
+      - name: Validate task.json – Download tasks.schema.json
         run: Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/microsoft/azure-pipelines-task-lib/master/tasks.schema.json' -OutFile 'tasks.schema.json'
 
-      - name: JSON VALIDATION – Validate task.json – Update tasks.schema.json
+      - name: Validate task.json – Update tasks.schema.json
         run: |-
           $FileContent = Get-Content -Path 'tasks.schema.json' -Raw
           $FileContent = $FileContent -replace 'draft-04', 'draft-07'


### PR DESCRIPTION
## Summary

Adding a markdown link validation task to the build to ensure that links are correct and continue to work as expected.

## Test Plan

There are no product code changes, so this change will be sufficiently validated once the build process (automatically invoked when this build is created) runs correctly.
