### PR TITLE
Downgrading PR Metrics API Version requirement

### DIFF
--- a/PipelinesTasks/PRMetricsV1/task/CodeMetricsCalculator.Tests.ps1
+++ b/PipelinesTasks/PRMetricsV1/task/CodeMetricsCalculator.Tests.ps1
@@ -221,7 +221,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/' +
-                              '12345?api-version=6.0')
+                              '12345?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -232,7 +232,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -267,7 +267,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/' +
-                              '12345?api-version=6.0 ' +
+                              '12345?api-version=4.1 ' +
                               "{`"description`":`"$([char]0x274C) **Add a description.**`"," +
                               "`"title`":`"XS$([char]0x26A0)$([char]0xFE0F) $([char]0x25FE) Title`"}")
             }
@@ -279,7 +279,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq ("{`"description`":`"$([char]0x274C) **Add a description.**`"," +
@@ -376,7 +376,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads?api-version=6.0')
+                              'threads?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -386,7 +386,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -408,7 +408,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'iterations?api-version=6.0')
+                              'iterations?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -422,7 +422,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/iterations' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -475,7 +475,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('POST ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads?api-version=6.0 ' +
+                              'threads?api-version=4.1 ' +
                               '{"comments":[{"content":"# Metrics for iteration 1' +
                               $([Environment]::NewLine) +
                               "$([char]0x2714) **Thanks for keeping your pull request small.**" +
@@ -498,7 +498,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'POST' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq ('{"comments":[{"content":"# Metrics for iteration 1' +
@@ -534,7 +534,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/' +
-                              '1?api-version=6.0 {"status":1}')
+                              '1?api-version=4.1 {"status":1}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -544,7 +544,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/1' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"status":1}' -and
@@ -568,7 +568,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -like ('PATCH ' +
                                 'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                                 'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/properties?' +
-                                'api-version=6.0-preview.1 *') -and
+                                'api-version=4.1-preview.1 *') -and
                 $Message -like '*{"op":"replace","path":"/PRMetrics.Size","value":"XS"}*' -and
                 $Message -like '*{"op":"replace","path":"/PRMetrics.TestCoverage","value":false}*' -and
                 $Message -like '*{"op":"replace","path":"/PRMetrics.ProductCode","value":1}*' -and
@@ -585,7 +585,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/properties?' +
-                          'api-version=6.0-preview.1') -and
+                          'api-version=4.1-preview.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -like '*{"op":"replace","path":"/PRMetrics.Size","value":"XS"}*' -and
@@ -690,7 +690,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads?api-version=6.0')
+                              'threads?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -700,7 +700,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -722,7 +722,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'iterations?api-version=6.0')
+                              'iterations?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -736,7 +736,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/iterations' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -789,7 +789,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('POST ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads?api-version=6.0 ' +
+                              'threads?api-version=4.1 ' +
                               '{"comments":[{"content":"# Metrics for iteration 1' +
                               $([Environment]::NewLine) +
                               "$([char]0x2714) **Thanks for keeping your pull request small.**" +
@@ -810,7 +810,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'POST' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq ('{"comments":[{"content":"# Metrics for iteration 1' +
@@ -844,7 +844,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/' +
-                              '1?api-version=6.0 {"status":4}')
+                              '1?api-version=4.1 {"status":4}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -854,7 +854,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/1' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"status":4}' -and
@@ -878,7 +878,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -like ('PATCH ' +
                                 'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                                 'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/properties?' +
-                                'api-version=6.0-preview.1 *') -and
+                                'api-version=4.1-preview.1 *') -and
                 $Message -like '*{"op":"replace","path":"/PRMetrics.Size","value":"XS"}*' -and
                 $Message -like '*{"op":"replace","path":"/PRMetrics.ProductCode","value":1}*' -and
                 $Message -like '*{"op":"replace","path":"/PRMetrics.TestCode","value":0}*' -and
@@ -895,7 +895,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/properties?' +
-                          'api-version=6.0-preview.1') -and
+                          'api-version=4.1-preview.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -like '*{"op":"replace","path":"/PRMetrics.Size","value":"XS"}*' -and
@@ -1003,7 +1003,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads?api-version=6.0')
+                              'threads?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -1027,7 +1027,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -1054,7 +1054,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'iterations?api-version=6.0')
+                              'iterations?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -1071,7 +1071,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/iterations' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -1130,7 +1130,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('POST ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads/1/comments?api-version=6.0 ' +
+                              'threads/1/comments?api-version=4.1 ' +
                               '{"parentCommentId":2,"content":"# Metrics for iteration 2' +
                               $([Environment]::NewLine) +
                               "$([char]0x2714) **Thanks for keeping your pull request small.**" +
@@ -1153,7 +1153,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'POST' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/1/' +
-                          'comments?api-version=6.0') -and
+                          'comments?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq ('{"parentCommentId":2,"content":"# Metrics for iteration 2' +
@@ -1183,7 +1183,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/' +
-                              '1?api-version=6.0 {"status":1}')
+                              '1?api-version=4.1 {"status":1}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -1193,7 +1193,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/1' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"status":1}' -and
@@ -1212,7 +1212,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -like ('PATCH ' +
                                 'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                                 'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/properties?' +
-                                'api-version=6.0-preview.1 *') -and
+                                'api-version=4.1-preview.1 *') -and
                 $Message -like '*{"op":"replace","path":"/PRMetrics.Size","value":"XS"}*' -and
                 $Message -like '*{"op":"replace","path":"/PRMetrics.TestCoverage","value":false}*' -and
                 $Message -like '*{"op":"replace","path":"/PRMetrics.ProductCode","value":1}*' -and
@@ -1229,7 +1229,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/properties?' +
-                          'api-version=6.0-preview.1') -and
+                          'api-version=4.1-preview.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -like '*{"op":"replace","path":"/PRMetrics.Size","value":"XS"}*' -and
@@ -1338,7 +1338,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads?api-version=6.0')
+                              'threads?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -1362,7 +1362,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -1389,7 +1389,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'iterations?api-version=6.0')
+                              'iterations?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -1403,7 +1403,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/iterations' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -1519,7 +1519,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads?api-version=6.0')
+                              'threads?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -1558,7 +1558,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -1589,7 +1589,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'iterations?api-version=6.0')
+                              'iterations?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -1603,7 +1603,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/iterations' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -1641,7 +1641,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('POST ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads?api-version=6.0 ' +
+                              'threads?api-version=4.1 ' +
                               '{"comments":[{"content":' +
                               "`"$([char]0x2757) **This file may not need to be reviewed.**`"}]," +
                               '"threadContext":{"filePath":"/Ignored2.cs",' +
@@ -1656,7 +1656,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'POST' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq ("{`"comments`":[{`"content`":`"$([char]0x2757) **This file may not need to be " +
@@ -1675,7 +1675,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('POST ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads?api-version=6.0 ' +
+                              'threads?api-version=4.1 ' +
                               '{"comments":[{"content":' +
                               "`"$([char]0x2757) **This file may not need to be reviewed.**`"}]," +
                               '"threadContext":{"filePath":"/Ignored3.cs",' +
@@ -1690,7 +1690,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'POST' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq ("{`"comments`":[{`"content`":`"$([char]0x2757) **This file may not need to be " +
@@ -1718,7 +1718,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/' +
-                              '3?api-version=6.0 {"status":4}')
+                              '3?api-version=4.1 {"status":4}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -1728,7 +1728,7 @@ Describe -Name 'CodeMetricsCalculator' {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/CodeMetricsCalculator/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/3' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"status":4}' -and

--- a/PipelinesTasks/PRMetricsV1/task/Invokers/AzureReposInvoker.Tests.ps1
+++ b/PipelinesTasks/PRMetricsV1/task/Invokers/AzureReposInvoker.Tests.ps1
@@ -106,7 +106,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0')
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -115,7 +115,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -161,7 +161,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/iterations?api-version=6.0')
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/iterations?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -171,7 +171,7 @@ Describe -Name 'AzureReposInvoker' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
                           '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/iterations' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -217,7 +217,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=6.0')
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -226,7 +226,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -338,7 +338,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0 ' +
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1 ' +
                               '{"description":"Description","title":"Title"}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
@@ -348,7 +348,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"description":"Description","title":"Title"}' -and
@@ -395,7 +395,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0 ' +
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1 ' +
                               '{"description":"Description"}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
@@ -405,7 +405,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"description":"Description"}' -and
@@ -452,7 +452,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0 ' +
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1 ' +
                               '{"description":"Description"}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
@@ -462,7 +462,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"description":"Description"}' -and
@@ -509,7 +509,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0 ' +
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1 ' +
                               '{"description":"Description"}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
@@ -519,7 +519,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"description":"Description"}' -and
@@ -566,7 +566,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0 ' +
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1 ' +
                               '{"title":"Title"}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
@@ -576,7 +576,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"title":"Title"}' -and
@@ -623,7 +623,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0 ' +
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1 ' +
                               '{"title":"Title"}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
@@ -633,7 +633,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"title":"Title"}' -and
@@ -680,7 +680,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0 ' +
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1 ' +
                               '{"title":"Title"}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
@@ -690,7 +690,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"title":"Title"}' -and
@@ -738,7 +738,7 @@ Describe -Name 'AzureReposInvoker' {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
                               '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/' +
-                              '1?api-version=6.0 {"status":2}')
+                              '1?api-version=4.1 {"status":2}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -747,7 +747,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/1?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/1?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"status":2}' -and
@@ -794,7 +794,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('PATCH ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0 ' +
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1 ' +
                               '{"title":"\""}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
@@ -804,7 +804,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"title":"\""}' -and
@@ -848,7 +848,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('POST ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=6.0 ' +
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=4.1 ' +
                               '{"comments":[{"content":"Comment"}]}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
@@ -858,7 +858,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'POST' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"comments":[{"content":"Comment"}]}' -and
@@ -903,7 +903,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('POST ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=6.0 ' +
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=4.1 ' +
                               '{"comments":[{"content":"Comment"}],"threadContext":{"filePath":"/File.cs",' +
                               '"rightFileStart":{"line":1,"offset":1},"rightFileEnd":{"line":1,"offset":2}}}')
             }
@@ -914,7 +914,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'POST' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq ('{"comments":[{"content":"Comment"}],"threadContext":{"filePath":"/File.cs",' +
@@ -960,7 +960,7 @@ Describe -Name 'AzureReposInvoker' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('POST ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=6.0 ' +
+                              '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=4.1 ' +
                               '{"comments":[{"content":"Comment"}],"threadContext":{"filePath":"/File.cs",' +
                               '"leftFileStart":{"line":1,"offset":1},"leftFileEnd":{"line":1,"offset":2}}}')
             }
@@ -971,7 +971,7 @@ Describe -Name 'AzureReposInvoker' {
             } -Verifiable -ParameterFilter {
                 $Method -eq 'POST' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
-                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=6.0') -and
+                          '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq ('{"comments":[{"content":"Comment"}],"threadContext":{"filePath":"/File.cs",' +
@@ -1021,7 +1021,7 @@ Describe -Name 'AzureReposInvoker' {
                 $Message -eq ('POST ' +
                               'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
                               '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/1/' +
-                              'comments?api-version=6.0 {"parentCommentId":2,"content":"Comment"}')
+                              'comments?api-version=4.1 {"parentCommentId":2,"content":"Comment"}')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -1031,7 +1031,7 @@ Describe -Name 'AzureReposInvoker' {
                 $Method -eq 'POST' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
                           '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads/1/comments' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq '{"parentCommentId":2,"content":"Comment"}' -and
@@ -1076,7 +1076,7 @@ Describe -Name 'AzureReposInvoker' {
                 $Message -like ('PATCH ' +
                                 'https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
                                 '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/properties?' +
-                                'api-version=6.0-preview.1 *') -and
+                                'api-version=4.1-preview.1 *') -and
                 $Message -like '*{"op":"replace","path":"/Element1","value":"Value1"}*' -and
                 $Message -like '*{"op":"replace","path":"/Element2","value":"Value2"}*' -and
                 $Message -like '*{"op":"replace","path":"/Element3","value":true}*' -and
@@ -1090,7 +1090,7 @@ Describe -Name 'AzureReposInvoker' {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/AzureReposInvoker/_apis/git/repositories/' +
                           '41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/properties?' +
-                          'api-version=6.0-preview.1') -and
+                          'api-version=4.1-preview.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -like '*{"op":"replace","path":"/Element1","value":"Value1"}*' -and

--- a/PipelinesTasks/PRMetricsV1/task/Invokers/AzureReposInvoker.ps1
+++ b/PipelinesTasks/PRMetricsV1/task/Invokers/AzureReposInvoker.ps1
@@ -174,7 +174,7 @@ class AzureReposInvoker {
 
     hidden [string] GetUri([string] $uriElements, [string] $uriSuffix) {
         [Logger]::Log('* [AzureReposInvoker]::GetUri() hidden')
-        return "$($this.BaseUri)$($uriElements)?api-version=6.0$($uriSuffix)"
+        return "$($this.BaseUri)$($uriElements)?api-version=4.1$($uriSuffix)"
     }
 
     hidden [void] WriteOutput([PSCustomObject] $output) {

--- a/PipelinesTasks/PRMetricsV1/task/PRMetrics.Tests.ps1
+++ b/PipelinesTasks/PRMetricsV1/task/PRMetrics.Tests.ps1
@@ -337,7 +337,7 @@ Describe -Name 'PRMetrics' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/' +
-                              '12345?api-version=6.0')
+                              '12345?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -348,7 +348,7 @@ Describe -Name 'PRMetrics' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?' +
-                          'api-version=6.0') -and
+                          'api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -382,7 +382,7 @@ Describe -Name 'PRMetrics' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('PATCH https://dev.azure.com/prmetrics/PRMetrics/_apis/' +
                               'git/repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/' +
-                              '12345?api-version=6.0 ' +
+                              '12345?api-version=4.1 ' +
                               "{`"description`":`"$([char]0x274C) **Add a description.**`"," +
                               "`"title`":`"XS$([char]0x26A0)$([char]0xFE0F) $([char]0x25FE) Title`"}")
             }
@@ -394,7 +394,7 @@ Describe -Name 'PRMetrics' {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq ("{`"description`":`"$([char]0x274C) **Add a description.**`"," +
@@ -415,7 +415,7 @@ Describe -Name 'PRMetrics' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('GET https://dev.azure.com/prmetrics/PRMetrics/_apis/' +
                               'git/repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads?api-version=6.0')
+                              'threads?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -439,7 +439,7 @@ Describe -Name 'PRMetrics' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -460,7 +460,7 @@ Describe -Name 'PRMetrics' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'iterations?api-version=6.0')
+                              'iterations?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -474,7 +474,7 @@ Describe -Name 'PRMetrics' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/iterations' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -621,7 +621,7 @@ Describe -Name 'PRMetrics' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/' +
-                              '12345?api-version=6.0')
+                              '12345?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -632,7 +632,7 @@ Describe -Name 'PRMetrics' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345?' +
-                          'api-version=6.0') -and
+                          'api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -666,7 +666,7 @@ Describe -Name 'PRMetrics' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('PATCH https://dev.azure.com/prmetrics/PRMetrics/_apis/' +
                               'git/repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/' +
-                              '12345?api-version=6.0 ' +
+                              '12345?api-version=4.1 ' +
                               "{`"description`":`"$([char]0x274C) **Add a description.**`"," +
                               "`"title`":`"XS$([char]0x26A0)$([char]0xFE0F) $([char]0x25FE) Title`"}")
             }
@@ -678,7 +678,7 @@ Describe -Name 'PRMetrics' {
                 $Method -eq 'PATCH' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN' -and
                 $Body -eq ("{`"description`":`"$([char]0x274C) **Add a description.**`"," +
@@ -699,7 +699,7 @@ Describe -Name 'PRMetrics' {
             Mock -CommandName 'Write-Verbose' -MockWith {} -Verifiable -ParameterFilter {
                 $Message -eq ('GET https://dev.azure.com/prmetrics/PRMetrics/_apis/' +
                               'git/repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'threads?api-version=6.0')
+                              'threads?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 return [PSCustomObject]@{
@@ -723,7 +723,7 @@ Describe -Name 'PRMetrics' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/threads' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -744,7 +744,7 @@ Describe -Name 'PRMetrics' {
                 $Message -eq ('GET ' +
                               'https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                               'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                              'iterations?api-version=6.0')
+                              'iterations?api-version=4.1')
             }
             Mock -CommandName 'Invoke-RestMethod' -MockWith {
                 throw [System.NotImplementedException]'Invoke-RestMethod must not be called.'
@@ -752,7 +752,7 @@ Describe -Name 'PRMetrics' {
                 $Method -eq 'GET' -and
                 $Uri -eq ('https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                           'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/iterations' +
-                          '?api-version=6.0') -and
+                          '?api-version=4.1') -and
                 $Headers.Count -eq 1 -and
                 $Headers.Authorization -eq 'Bearer ACCESSTOKEN'
             }
@@ -829,7 +829,7 @@ Describe -Name 'PRMetrics' {
                 $MessageData -eq ('GET ' +
                                   'https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                                   'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/' +
-                                  '12345?api-version=6.0')
+                                  '12345?api-version=4.1')
             }
             Mock -CommandName 'Write-Information' -MockWith {} -Verifiable -ParameterFilter {
                 $MessageData -eq '* [AzureReposInvoker]::WriteOutput() hidden'
@@ -861,7 +861,7 @@ Describe -Name 'PRMetrics' {
             Mock -CommandName 'Write-Information' -MockWith {} -Verifiable -ParameterFilter {
                 $MessageData -eq ('PATCH https://dev.azure.com/prmetrics/PRMetrics/' +
                                   '_apis/git/repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/' +
-                                  '12345?api-version=6.0 ' +
+                                  '12345?api-version=4.1 ' +
                                   "{`"description`":`"$([char]0x274C) **Add a description.**`"," +
                                   "`"title`":`"XS$([char]0x26A0)$([char]0xFE0F) $([char]0x25FE) Title`"}")
             }
@@ -879,7 +879,7 @@ Describe -Name 'PRMetrics' {
             Mock -CommandName 'Write-Information' -MockWith {} -Verifiable -ParameterFilter {
                 $MessageData -eq ('GET https://dev.azure.com/prmetrics/PRMetrics/' +
                                   '_apis/git/repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/' +
-                                  '12345/threads?api-version=6.0')
+                                  '12345/threads?api-version=4.1')
             }
             Mock -CommandName 'Write-Information' -MockWith {} -Verifiable -ParameterFilter {
                 $MessageData -like '*"value": *' -and
@@ -898,7 +898,7 @@ Describe -Name 'PRMetrics' {
                 $MessageData -eq ('GET ' +
                                   'https://dev.azure.com/prmetrics/PRMetrics/_apis/git/' +
                                   'repositories/41d31ec7-6c0a-467d-9e51-0cac9ae9a598/pullRequests/12345/' +
-                                  'iterations?api-version=6.0')
+                                  'iterations?api-version=4.1')
             }
             Mock -CommandName 'Write-Information' -MockWith {} -Verifiable -ParameterFilter {
                 $MessageData -eq '* [PullRequest]::GetCurrentIteration() static'

--- a/PipelinesTasks/PRMetricsV1/task/task.json
+++ b/PipelinesTasks/PRMetricsV1/task/task.json
@@ -8,9 +8,6 @@
   "helpMarkDown": "[More information](https://github.com/microsoft/OMEX-Azure-DevOps-Extensions/blob/main/PipelinesTasks/PRMetricsV1/README.md)",
   "author": "Microsoft Corporation",
   "category": "Azure Pipelines",
-  "demands": [
-    "api-version/6.0"
-  ],
   "minimumAgentVersion": "2.141.0",
   "version": {
     "Major": %MAJOR%,

--- a/PipelinesTasks/PRMetricsV1/task/task.json
+++ b/PipelinesTasks/PRMetricsV1/task/task.json
@@ -8,6 +8,9 @@
   "helpMarkDown": "[More information](https://github.com/microsoft/OMEX-Azure-DevOps-Extensions/blob/main/PipelinesTasks/PRMetricsV1/README.md)",
   "author": "Microsoft Corporation",
   "category": "Azure Pipelines",
+  "demands": [
+    "api-version/4.1"
+  ],
   "minimumAgentVersion": "2.141.0",
   "version": {
     "Major": %MAJOR%,

--- a/PipelinesTasks/PRMetricsV1/vss-extension.json
+++ b/PipelinesTasks/PRMetricsV1/vss-extension.json
@@ -28,6 +28,9 @@
   "scopes": [
     "vso.code_write"
   ],
+  "demands": [
+    "api-version/4.1"
+  ],
   "categories": [
     "Azure Pipelines"
   ],

--- a/PipelinesTasks/PRMetricsV1/vss-extension.json
+++ b/PipelinesTasks/PRMetricsV1/vss-extension.json
@@ -28,9 +28,6 @@
   "scopes": [
     "vso.code_write"
   ],
-  "demands": [
-    "api-version/6.0"
-  ],
   "categories": [
     "Azure Pipelines"
   ],


### PR DESCRIPTION
## Summary

Downgrading the API version requirement from v6.0 to v4.1, which will allow the task to run with older versions of Azure DevOps.

This PR is designed to help resolve the issue raised in #20.

## Test Plan

- Unit tests continue to run successfully.
- Testing was performed locally with no difference in behaviour observed.
- A previous version of this task worked successfully with v4.1, which provides assurance that the APIs should also work with v4.1. It should be noted, however, that a few minor changes were made after the move from v4.1.