### PR TITLE
Converting PullRequest.ps1 (Part 1)

### DIFF
--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/Strings/resources.resjson/en-US/resources.resjson
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/Strings/resources.resjson/en-US/resources.resjson
@@ -39,5 +39,35 @@
   "loc.input.label.testFactor.comment": "The label for the 'test ratio' setting on the Azure Pipelines task properties page.",
 
   "loc.instanceNameFormat": "PR Metrics",
-  "loc.instanceNameFormat.comment": "The name of the task on the Azure Pipelines task properties page."
+  "loc.instanceNameFormat.comment": "The name of the task on the Azure Pipelines task properties page.",
+
+  "loc.messages.updaters.pullRequest.addDescription": "❌ **Add a description.**",
+  "loc.messages.updaters.pullRequest.addDescription.comment": "The description to add to the pull request if none exists.",
+
+  "loc.messages.updaters.pullRequest.titleFormat": "%s ◾ %s",
+  "loc.messages.updaters.pullRequest.titleFormat.comment": "The title format. The first placeholder will be replaced by the title size and test coverage prefix, and the second placeholder will be replaced by the original pull request title.",
+
+  "loc.messages.updaters.pullRequest.titleSizeIndicatorFormat": "%s%s",
+  "loc.messages.updaters.pullRequest.titleSizeIndicatorFormat.comment": "The title size and test coverage prefix format. The first placeholder will be replaced by the title size prefix, and the second placeholder will be replaced by the test coverage prefix.",
+
+  "loc.messages.updaters.pullRequest.titleSizeL": "L",
+  "loc.messages.updaters.pullRequest.titleSizeL.comment": "The title size prefix for a large pull request.",
+
+  "loc.messages.updaters.pullRequest.titleSizeM": "M",
+  "loc.messages.updaters.pullRequest.titleSizeM.comment": "The title size prefix for a medium pull request.",
+
+  "loc.messages.updaters.pullRequest.titleSizeS": "S",
+  "loc.messages.updaters.pullRequest.titleSizeS.comment": "The title size prefix for a small pull request.",
+
+  "loc.messages.updaters.pullRequest.titleSizeXL": "%sXL",
+  "loc.messages.updaters.pullRequest.titleSizeXL.comment": "The title size prefix for an extra large pull request. The placeholder will be replaced with either an empty string or a number indicating a multiple of the extra large size.",
+
+  "loc.messages.updaters.pullRequest.titleSizeXS": "XS",
+  "loc.messages.updaters.pullRequest.titleSizeXS.comment": "The title size prefix for an extra small pull request.",
+
+  "loc.messages.updaters.pullRequest.titleTestsInsufficient": "⚠️",
+  "loc.messages.updaters.pullRequest.titleTestsInsufficient.comment": "The title test coverage prefix for a pull request with insufficient test coverage.",
+
+  "loc.messages.updaters.pullRequest.titleTestsSufficient": "✔",
+  "loc.messages.updaters.pullRequest.titleTestsSufficient.comment": "The title test coverage prefix for a pull request with sufficient test coverage."
 }

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/index.ts
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/index.ts
@@ -12,6 +12,7 @@ async function run (): Promise<void> {
 
     try {
       const taskLibWrapper: TaskLibWrapper = new TaskLibWrapper()
+      process.stdout.write('Description:' + taskLibWrapper.loc('updaters.pullRequest.addDescription'))
       const gitInvoker: GitInvoker = new GitInvoker(taskLibWrapper)
       process.stdout.write(gitInvoker.getDiffSummary())
     } catch (error) {

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/task.json
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/task.json
@@ -54,5 +54,17 @@
     "Node10": {
       "target": "index.js"
     }
+  },
+  "messages": {
+    "updaters.pullRequest.addDescription": "❌ **Add a description.**",
+    "updaters.pullRequest.titleFormat": "%s ◾ %s",
+    "updaters.pullRequest.titleSizeIndicatorFormat": "%s%s",
+    "updaters.pullRequest.titleSizeL": "L",
+    "updaters.pullRequest.titleSizeM": "M",
+    "updaters.pullRequest.titleSizeS": "S",
+    "updaters.pullRequest.titleSizeXL": "%sXL",
+    "updaters.pullRequest.titleSizeXS": "XS",
+    "updaters.pullRequest.titleTestsInsufficient": "⚠️",
+    "updaters.pullRequest.titleTestsSufficient": "✔"
   }
 }

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/task.loc.json
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/task.loc.json
@@ -54,5 +54,17 @@
     "Node10": {
       "target": "index.js"
     }
+  },
+  "messages": {
+    "updaters.pullRequest.addDescription": "ms-resource:loc.messages.updaters.pullRequest.addDescription",
+    "updaters.pullRequest.titleFormat": "ms-resource:loc.messages.updaters.pullRequest.titleFormat",
+    "updaters.pullRequest.titleSizeIndicatorFormat": "ms-resource:loc.messages.updaters.pullRequest.titleSizeIndicatorFormat",
+    "updaters.pullRequest.titleSizeL": "ms-resource:loc.messages.updaters.pullRequest.titleSizeL",
+    "updaters.pullRequest.titleSizeM": "ms-resource:loc.messages.updaters.pullRequest.titleSizeM",
+    "updaters.pullRequest.titleSizeS": "ms-resource:loc.messages.updaters.pullRequest.titleSizeS",
+    "updaters.pullRequest.titleSizeXL": "ms-resource:loc.messages.updaters.pullRequest.titleSizeXL",
+    "updaters.pullRequest.titleSizeXS": "ms-resource:loc.messages.updaters.pullRequest.titleSizeXS",
+    "updaters.pullRequest.titleTestsInsufficient": "ms-resource:loc.messages.updaters.pullRequest.titleTestsInsufficient",
+    "updaters.pullRequest.titleTestsSufficient": "ms-resource:loc.messages.updaters.pullRequest.titleTestsSufficient"
   }
 }

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/tests/updaters/pullRequest.spec.ts
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/tests/updaters/pullRequest.spec.ts
@@ -4,13 +4,24 @@
 import PullRequest from '../../updaters/pullRequest'
 import TaskLibWrapper from '../../wrappers/taskLibWrapper'
 import { expect } from 'chai'
-import { instance, mock, verify } from 'ts-mockito'
+import { instance, mock, verify, when } from 'ts-mockito'
+import async from 'async'
 
 describe('pullRequest.ts', (): void => {
   let taskLibWrapper: TaskLibWrapper
 
   beforeEach((): void => {
     taskLibWrapper = mock(TaskLibWrapper)
+    when(taskLibWrapper.loc('updaters.pullRequest.addDescription')).thenReturn('❌ **Add a description.**')
+    when(taskLibWrapper.loc('updaters.pullRequest.titleFormat', '(XS|S|M|L|\\d*XL)(✔|⚠️)?', '(.*)')).thenReturn('(XS|S|M|L|\\d*XL)(✔|⚠️)? ◾ (.*)')
+    when(taskLibWrapper.loc('updaters.pullRequest.titleSizeIndicatorFormat', '(XS|S|M|L|\\d*XL)', '(✔|⚠️)?')).thenReturn('(XS|S|M|L|\\d*XL)(✔|⚠️)?')
+    when(taskLibWrapper.loc('updaters.pullRequest.titleSizeL')).thenReturn('L')
+    when(taskLibWrapper.loc('updaters.pullRequest.titleSizeM')).thenReturn('M')
+    when(taskLibWrapper.loc('updaters.pullRequest.titleSizeS')).thenReturn('S')
+    when(taskLibWrapper.loc('updaters.pullRequest.titleSizeXL', '\\d*')).thenReturn('\\d*XL')
+    when(taskLibWrapper.loc('updaters.pullRequest.titleSizeXS')).thenReturn('XS')
+    when(taskLibWrapper.loc('updaters.pullRequest.titleTestsInsufficient')).thenReturn('⚠️')
+    when(taskLibWrapper.loc('updaters.pullRequest.titleTestsSufficient')).thenReturn('✔')
   })
 
   describe('isPullRequest()', (): void => {
@@ -82,5 +93,65 @@ describe('pullRequest.ts', (): void => {
       expect(result).to.equal(null)
       verify(taskLibWrapper.debug('* PullRequest.getUpdatedTitle()')).once()
     })
+
+    async.each(
+      [
+        'Title',
+        'PREFIX ◾ Title',
+        'PREFIX✔ ◾ Title',
+        'PREFIX⚠️ ◾ Title',
+        'PS ◾ Title',
+        'PS✔ ◾ Title',
+        'PS⚠️ ◾ Title'
+      ], (currentTitle: string): void => {
+        it(`should prefix the current title '${currentTitle}' when no prefix exists`, (): void => {
+          // Arrange
+          const pullRequest: PullRequest = new PullRequest(instance(taskLibWrapper))
+
+          // Act
+          const result: string | null = pullRequest.getUpdatedTitle(currentTitle, 'S✔')
+
+          // Assert
+          expect(result).to.equal(`S✔ ◾ ${currentTitle}`)
+          verify(taskLibWrapper.debug('* PullRequest.getUpdatedTitle()')).once()
+        })
+      })
+
+    async.each(
+      [
+        'XS✔ ◾ Title',
+        'XS⚠️ ◾ Title',
+        'XS ◾ Title',
+        'S✔ ◾ Title',
+        'S⚠️ ◾ Title',
+        'S ◾ Title',
+        'M✔ ◾ Title',
+        'M⚠️ ◾ Title',
+        'M ◾ Title',
+        'L✔ ◾ Title',
+        'L⚠️ ◾ Title',
+        'L ◾ Title',
+        'XL✔ ◾ Title',
+        'XL⚠️ ◾ Title',
+        'XL ◾ Title',
+        '2XL✔ ◾ Title',
+        '2XL⚠️ ◾ Title',
+        '2XL ◾ Title',
+        '20XL✔ ◾ Title',
+        '20XL⚠️ ◾ Title',
+        '20XL ◾ Title'
+      ], (currentTitle: string): void => {
+        it(`should update the current title '${currentTitle}' correctly`, (): void => {
+          // Arrange
+          const pullRequest: PullRequest = new PullRequest(instance(taskLibWrapper))
+
+          // Act
+          const result: string | null = pullRequest.getUpdatedTitle(currentTitle, 'PREFIX')
+
+          // Assert
+          expect(result).to.equal('PREFIX ◾ Title')
+          verify(taskLibWrapper.debug('* PullRequest.getUpdatedTitle()')).once()
+        })
+      })
   })
 })

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/tests/updaters/pullRequest.spec.ts
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/tests/updaters/pullRequest.spec.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import PullRequest from '../../updaters/pullRequest'
+import TaskLibWrapper from '../../wrappers/taskLibWrapper'
+import { expect } from 'chai'
+import { instance, mock, verify } from 'ts-mockito'
+
+describe('pullRequest.ts', (): void => {
+  let taskLibWrapper: TaskLibWrapper
+
+  beforeEach((): void => {
+    taskLibWrapper = mock(TaskLibWrapper)
+  })
+
+  describe('isPullRequest()', (): void => {
+    it('should return true when SYSTEM_PULLREQUEST_PULLREQUESTID is defined', (): void => {
+      // Arrange
+      process.env.SYSTEM_PULLREQUEST_PULLREQUESTID = 'refs/heads/develop'
+      const pullRequest: PullRequest = new PullRequest(instance(taskLibWrapper))
+
+      // Act
+      const result: boolean = pullRequest.isPullRequest()
+
+      // Assert
+      expect(result).to.equal(true)
+      verify(taskLibWrapper.debug('* PullRequest.isPullRequest()')).once()
+
+      // Disposal
+      delete process.env.SYSTEM_PULLREQUEST_PULLREQUESTID
+    })
+
+    it('should return false when SYSTEM_PULLREQUEST_PULLREQUESTID is not defined', (): void => {
+      // Arrange
+      delete process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
+      const pullRequest: PullRequest = new PullRequest(instance(taskLibWrapper))
+
+      // Act
+      const result: boolean = pullRequest.isPullRequest()
+
+      // Assert
+      expect(result).to.equal(false)
+      verify(taskLibWrapper.debug('* PullRequest.isPullRequest()')).once()
+    })
+  })
+})

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/tests/updaters/pullRequest.spec.ts
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/tests/updaters/pullRequest.spec.ts
@@ -43,4 +43,44 @@ describe('pullRequest.ts', (): void => {
       verify(taskLibWrapper.debug('* PullRequest.isPullRequest()')).once()
     })
   })
+
+  describe('getUpdatedDescription()', (): void => {
+    it('should return null when the current description is set', (): void => {
+      // Arrange
+      const pullRequest: PullRequest = new PullRequest(instance(taskLibWrapper))
+
+      // Act
+      const result: string | null = pullRequest.getUpdatedDescription('Description')
+
+      // Assert
+      expect(result).to.equal(null)
+      verify(taskLibWrapper.debug('* PullRequest.getUpdatedDescription()')).once()
+    })
+
+    it('should return the default description when the current description is empty', (): void => {
+      // Arrange
+      const pullRequest: PullRequest = new PullRequest(instance(taskLibWrapper))
+
+      // Act
+      const result: string | null = pullRequest.getUpdatedDescription('')
+
+      // Assert
+      expect(result).to.equal('❌ **Add a description.**')
+      verify(taskLibWrapper.debug('* PullRequest.getUpdatedDescription()')).once()
+    })
+  })
+
+  describe('getUpdatedTitle()', (): void => {
+    it('should return null when the current title is set to the expected title', (): void => {
+      // Arrange
+      const pullRequest: PullRequest = new PullRequest(instance(taskLibWrapper))
+
+      // Act
+      const result: string | null = pullRequest.getUpdatedTitle('S✔ ◾ Title', 'S✔')
+
+      // Assert
+      expect(result).to.equal(null)
+      verify(taskLibWrapper.debug('* PullRequest.getUpdatedTitle()')).once()
+    })
+  })
 })

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/updaters/pullRequest.ts
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/updaters/pullRequest.ts
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import TaskLibWrapper from '../wrappers/taskLibWrapper'
+
+/**
+ * A class for managing pull requests
+ */
+class PullRequest {
+  private taskLibWrapper: TaskLibWrapper;
+
+  /**
+   * Initializes a new instance of the PullRequest class.
+   * @param taskLibWrapper The wrapper around the Azure Pipelines Task Lib.
+   */
+  public constructor (taskLibWrapper: TaskLibWrapper) {
+    this.taskLibWrapper = taskLibWrapper
+  }
+
+  /**
+   * Determines whether the task is running against a pull request.
+   * @returns A value indicating whether the task is running against a pull request.
+   */
+  public isPullRequest (): boolean {
+    this.taskLibWrapper.debug('* PullRequest.isPullRequest()')
+
+    return process.env.SYSTEM_PULLREQUEST_PULLREQUESTID !== undefined
+  }
+
+  /**
+   * Gets the description to which to update the pull request's current description.
+   * @param currentDescription The pull request's current description.
+   * @returns The value to which to update the description or `null` if the description is not to be updated.
+   */
+  public getUpdatedDescription (currentDescription: string): string | null {
+    this.taskLibWrapper.debug('* PullRequest.getUpdatedDescription()')
+
+    if (currentDescription) {
+      return null
+    }
+
+    return '❌ **Add a description.**'
+  }
+
+  /**
+   * Gets the description to which to update the pull request's current title.
+   * @param currentTitle The pull request's current title.
+   * @param sizeIndicator The size indicator with which to prefix the title.
+   * @returns The value to which to update the title or `null` if the title is not to be updated.
+   */
+  public getUpdatedTitle (currentTitle: string, sizeIndicator: string): string | null {
+    this.taskLibWrapper.debug('* PullRequest.getUpdatedTitle()')
+
+    if (currentTitle.startsWith(`${sizeIndicator} ◾ `)) {
+      return null
+    }
+
+    const prefixRegExp: RegExp = /^(XS|S|M|L|XL|\d+XL)(✔|⚠️)\s◾\s/u
+    const originalTitle: string = currentTitle.replace(prefixRegExp, '')
+    return `${sizeIndicator} ◾ ${originalTitle}`
+  }
+}
+
+export default PullRequest

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/updaters/pullRequest.ts
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/updaters/pullRequest.ts
@@ -39,7 +39,7 @@ class PullRequest {
       return null
     }
 
-    return '❌ **Add a description.**'
+    return this.taskLibWrapper.loc('updaters.pullRequest.addDescription')
   }
 
   /**
@@ -55,8 +55,25 @@ class PullRequest {
       return null
     }
 
-    const prefixRegExp: RegExp = /^(XS|S|M|L|XL|\d+XL)(✔|⚠️)\s◾\s/u
-    const originalTitle: string = currentTitle.replace(prefixRegExp, '')
+    const sizeRegExp: string =
+      `(${this.taskLibWrapper.loc('updaters.pullRequest.titleSizeXS')}` +
+      `|${this.taskLibWrapper.loc('updaters.pullRequest.titleSizeS')}` +
+      `|${this.taskLibWrapper.loc('updaters.pullRequest.titleSizeM')}` +
+      `|${this.taskLibWrapper.loc('updaters.pullRequest.titleSizeL')}` +
+      `|${this.taskLibWrapper.loc('updaters.pullRequest.titleSizeXL', '\\d*')})`
+    const testsRegExp: string =
+      `(${this.taskLibWrapper.loc('updaters.pullRequest.titleTestsSufficient')}` +
+      `|${this.taskLibWrapper.loc('updaters.pullRequest.titleTestsInsufficient')})?`
+    const sizeIndicatorRegExp: string = this.taskLibWrapper.loc('updaters.pullRequest.titleSizeIndicatorFormat', sizeRegExp, testsRegExp)
+    const completeRegExp: string = `^${this.taskLibWrapper.loc('updaters.pullRequest.titleFormat', sizeIndicatorRegExp, '(.*)')}$`
+
+    const prefixRegExp: RegExp = new RegExp(completeRegExp, 'u')
+    const prefixRegExpMatches: RegExpMatchArray | null = currentTitle.match(prefixRegExp)
+    let originalTitle: string = currentTitle
+    if (prefixRegExpMatches !== null) {
+      originalTitle = prefixRegExpMatches[3]!
+    }
+
     return `${sizeIndicator} ◾ ${originalTitle}`
   }
 }

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/wrappers/taskLibWrapper.ts
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/wrappers/taskLibWrapper.ts
@@ -26,6 +26,16 @@ class TaskLibWrapper {
   public execSync (tool: string, args: string | string[], options?: IExecSyncOptions): IExecSyncResult {
     return taskLib.execSync(tool, args, options)
   }
+
+  /**
+   * Gets the localized string from the JSON resource file and optionally formats using the additional parameters.
+   * @param key The key of the resources string in the resource file.
+   * @param param Optional additional parameters for formatting the string.
+   * @returns The localized and formatted string.
+   */
+  public loc (key: string, ...param: any[]): string {
+    return taskLib.loc(key, ...param)
+  }
 }
 
 export default TaskLibWrapper


### PR DESCRIPTION
## Summary

Part 1 of the conversion of PullRequest.ps1 into the new TypeScript libraries.

I'm pushing out this PR in phases – this being part 1 – as it introduces some infrastructure that I expect will be of use within the other PRs. This includes:
- Addition of resources and mechanism for accessing resources.
- Use of `async.each` for parameterised unit tests.

## Test Plan

100% unit test coverage of new code.

Validated via the build at https://github.com/microsoft/OMEX-Azure-DevOps-Extensions/runs/2166752602?check_suite_focus=true