### PR TITLE
PR Metrics: Correcting support for binary files

### DIFF
--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/Strings/resources.resjson/en-US/resources.resjson
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/Strings/resources.resjson/en-US/resources.resjson
@@ -4,7 +4,7 @@
   "loc.description": "Augments pull request titles to let reviewers quickly determine PR size and test coverage.",
   "loc.description.comment": "The description of the task.",
 
-  "loc.friendlyName": "PR Metrics 1.1.4",
+  "loc.friendlyName": "PR Metrics 1.1.5",
   "loc.friendlyName.comment": "The name of the task.",
 
   "loc.helpMarkDown": "[More information](https://github.com/microsoft/OMEX-Azure-DevOps-Extensions/blob/main/PipelinesTasks/PRMetrics/README.md)",

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/package-lock.json
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prmetrics",
-  "version": "1.1.0",
+  "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prmetrics",
-      "version": "1.1.0",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "azure-devops-node-api": "^8.1.1",

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/package.json
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "prmetrics",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Augments pull request titles to let reviewers quickly determine PR size and test coverage.",
   "main": "index.js",
   "scripts": {

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/src/metrics/codeMetrics.ts
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/src/metrics/codeMetrics.ts
@@ -209,7 +209,7 @@ export default class CodeMetrics {
       } else {
         linesAddedNumber = parseInt(linesAddedElement)
         if (isNaN(linesAddedNumber)) {
-          throw Error(`Could not parse '${elements[0]}' from line '${line}'.`)
+          throw Error(`Could not parse '${linesAddedElement}' from line '${line}'.`)
         }
       }
 

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/src/metrics/codeMetrics.ts
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/src/metrics/codeMetrics.ts
@@ -201,9 +201,16 @@ export default class CodeMetrics {
         .replace(/{.*? => ([^}]+?)}/g, '$1')
         .replace(/.*? => ([^}]+?)/g, '$1')
 
-      const linesAddedNumber: number = parseInt(elements[0]!)
-      if (isNaN(linesAddedNumber)) {
-        throw Error(`Could not parse '${elements[0]}' from line '${line}'.`)
+      // Parse the number of lines added. For binary files, the lines added will be '-'.
+      let linesAddedNumber: number
+      const linesAddedElement: string = elements[0]!
+      if (linesAddedElement === '-') {
+        linesAddedNumber = 0
+      } else {
+        linesAddedNumber = parseInt(linesAddedElement)
+        if (isNaN(linesAddedNumber)) {
+          throw Error(`Could not parse '${elements[0]}' from line '${line}'.`)
+        }
       }
 
       result.push({

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/task.json
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/task.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/azure-pipelines-task-lib/master/tasks.schema.json",
   "id": "907d3b28-6b37-4ac7-ac75-9631ee53e512",
   "name": "prmetrics",
-  "friendlyName": "PR Metrics 1.1.4",
+  "friendlyName": "PR Metrics 1.1.5",
   "description": "Augments pull request titles to let reviewers quickly determine PR size and test coverage.",
   "helpUrl": "https://github.com/microsoft/OMEX-Azure-DevOps-Extensions/blob/main/PipelinesTasks/PRMetrics/README.md",
   "helpMarkDown": "[More information](https://github.com/microsoft/OMEX-Azure-DevOps-Extensions/blob/main/PipelinesTasks/PRMetrics/README.md)",
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 4
+    "Patch": 5
   },
   "instanceNameFormat": "PR Metrics",
   "inputs": [

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/task.loc.json
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 4
+    "Patch": 5
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [

--- a/PipelinesTasks/PRMetrics/buildAndReleaseTask/tests/metrics/codeMetrics.spec.ts
+++ b/PipelinesTasks/PRMetrics/buildAndReleaseTask/tests/metrics/codeMetrics.spec.ts
@@ -181,7 +181,8 @@ describe('codeMetrics.ts', (): void => {
       ['1\t0\tfolder/tests/file.ts', 'XS', true, new CodeMetricsData(0, 1, 0)],
       ['1\t1\tfa/b => folder/test.ts', 'XS', true, new CodeMetricsData(0, 1, 0)],
       ['1\t1\tf{a => older}/{b => test.ts}', 'XS', true, new CodeMetricsData(0, 1, 0)],
-      ['0\t0\tfile.ts\n', 'XS', true, new CodeMetricsData(0, 0, 0)]
+      ['0\t0\tfile.ts\n', 'XS', true, new CodeMetricsData(0, 0, 0)],
+      ['-\t-\tfile.ts', 'XS', true, new CodeMetricsData(0, 0, 0)]
     ], (data: [string, string, boolean, CodeMetricsData]): void => {
       it(`with default inputs and git diff '${data[0].replace('\n', '\\n')}', returns '${data[1]}' size and '${data[2]}' test coverage`, (): void => {
         // Arrange


### PR DESCRIPTION
## Summary

Within `git diff`, the number of lines of code added to a binary file is displayed as `-`, which results in an error being thrown within the PR Metrics task.

This change corrects this issue, switching the `-` to `0` lines added in the total calculation.

This change also updates the release version to v1.1.5 to enable immediate release to the Marketplace.

## Testing

Validated that this case works via unit testing.
