### PR TITLE
PR Metrics: Bumping the version number

### DIFF
--- a/PipelinesTasks/PRMetrics/vss-extension.json
+++ b/PipelinesTasks/PRMetrics/vss-extension.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "id": "prmetrics",
   "name": "PR Metrics",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "publisher": "ms-omex",
   "description": "Augments pull request titles to let reviewers quickly determine PR size and test coverage.",
   "public": true,


### PR DESCRIPTION
## Summary

Bumping the version number of PR Metrics in vss-extension.json to enable publishing to the Visual Studio Marketplace.

This addresses a missed version bump from one remaining file.

## Testing

Unit tests continue to pass.