### PR TITLE
Changing dependabot cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    open-pull-requests-limit: 0
     schedule:
       interval: monthly
     labels:
@@ -13,6 +14,7 @@ updates:
 
   - package-ecosystem: npm
     directory: /
+    open-pull-requests-limit: 0
     schedule:
       interval: monthly
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,13 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
     labels:
       - dependencies
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
     labels:
       - dependencies


### PR DESCRIPTION
## Summary

Changing the dependabot cadence from daily to monthly.

Currently, some dependencies are updated very frequently – up to multiple times per week – but leveraging updates this frequently delivers little value to the PR Metrics extension. Therefore, to reduce dependabot PR churn and maintainance costs, the update cadence is being reduced from daily to monthly.