### PR TITLE
Re-enabling dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
     schedule:
       interval: monthly
     labels:
@@ -14,7 +14,7 @@ updates:
 
   - package-ecosystem: npm
     directory: /
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
     schedule:
       interval: monthly
     labels:


### PR DESCRIPTION
## Summary

Dependabot updates were switched off temporarily. Re-enabling these to send out updates on a monthly cadence.